### PR TITLE
Update views.py - Generic View Import statement

### DIFF
--- a/axians_netbox_pdu/views.py
+++ b/axians_netbox_pdu/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.shortcuts import get_object_or_404, render
 from django.views.generic import View
 
-from utilities.views import BulkDeleteView, BulkImportView, ObjectEditView, ObjectListView
+from netbox.views.generic import BulkDeleteView, BulkImportView, ObjectEditView, ObjectListView
 
 from .filters import PDUConfigFilter
 from .forms import PDUConfigCSVForm, PDUConfigFilterForm, PDUConfigForm


### PR DESCRIPTION
They seem to have updated the namespace under whcih these are exported. This tweak allows it to run on 2.10.2 for me :+1: 

Fixes #17 