### PR TITLE
2.10 compatibility changes

### DIFF
--- a/axians_netbox_pdu/navigation.py
+++ b/axians_netbox_pdu/navigation.py
@@ -10,14 +10,14 @@ menu_items = (
             PluginMenuButton(
                 link="plugins:axians_netbox_pdu:pduconfig_add",
                 title="Add",
-                icon_class="fa fa-plus",
+                icon_class="mdi mdi-plus-thick",
                 color=ButtonColorChoices.GREEN,
                 permissions=["axians_netbox_pdu.add_pduconfig"],
             ),
             PluginMenuButton(
                 link="plugins:axians_netbox_pdu:pduconfig_import",
                 title="Bulk Add",
-                icon_class="fa fa-download",
+                icon_class="mdi mdi-database-import-outline",
                 color=ButtonColorChoices.BLUE,
                 permissions=["axians_netbox_pdu.add_pduconfig"],
             ),

--- a/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_edit.html
+++ b/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_edit.html
@@ -1,2 +1,2 @@
-{% extends 'utilities/obj_edit.html' %}
+{% extends 'generic/object_edit.html' %}
 {% load form_helpers %}

--- a/axians_netbox_pdu/views.py
+++ b/axians_netbox_pdu/views.py
@@ -26,7 +26,7 @@ class PDUConfigCreateView(PermissionRequiredMixin, ObjectEditView):
 
     permission_required = "axians_netbox_pdu.add_pduconfig"
     model = PDUConfig
-    # queryset = PDUConfig.objects.all()
+    queryset = PDUConfig.objects.all()
     model_form = PDUConfigForm
     template_name = "axians_netbox_pdu/pduconfig_edit.html"
     default_return_url = "plugins:axians_netbox_pdu:pduconfig_list"


### PR DESCRIPTION
The changes in navigation.py supports the 'Switch to Material Design icons' in the plugins menu.
The pdu_config_edit.html now points to the new location for object_edit.html as part of the 'Clean up generic view templates'.
The commented out line in views.py was causing the 'NoneType object has no attribute 'model' when adding a new PDU configuration in 2.10. Possible fix for #14 and #16?
