### PR TITLE
2.11 compatibility fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Visual Studio stuff
+.vs/

--- a/axians_netbox_pdu/filters.py
+++ b/axians_netbox_pdu/filters.py
@@ -2,12 +2,12 @@ import django_filters
 from django.db.models import Q
 
 from dcim.models import Device, DeviceType, Manufacturer
-from utilities.filters import NameSlugSearchFilterSet
 
 from .models import PDUConfig, PDUStatus
 
+from netbox.filtersets import OrganizationalModelFilterSet
 
-class PDUConfigFilter(NameSlugSearchFilterSet):
+class PDUConfigFilter(OrganizationalModelFilterSet):
     """Filter PDUConfig instances."""
 
     q = django_filters.CharFilter(method="search", label="Search",)
@@ -42,7 +42,7 @@ class PDUConfigFilter(NameSlugSearchFilterSet):
         return queryset.filter(qs_filter)
 
 
-class PDUStatusFilter(NameSlugSearchFilterSet):
+class PDUStatusFilter(OrganizationalModelFilterSet):
     """Filter PDUStatus instances."""
 
     q = django_filters.CharFilter(method="search", label="Search",)

--- a/axians_netbox_pdu/navigation.py
+++ b/axians_netbox_pdu/navigation.py
@@ -10,14 +10,14 @@ menu_items = (
             PluginMenuButton(
                 link="plugins:axians_netbox_pdu:pduconfig_add",
                 title="Add",
-                icon_class="fa fa-plus",
+                icon_class="mdi mdi-plus-thick",
                 color=ButtonColorChoices.GREEN,
                 permissions=["axians_netbox_pdu.add_pduconfig"],
             ),
             PluginMenuButton(
                 link="plugins:axians_netbox_pdu:pduconfig_import",
                 title="Bulk Add",
-                icon_class="fa fa-download",
+                icon_class="mdi mdi-database-import-outline",
                 color=ButtonColorChoices.BLUE,
                 permissions=["axians_netbox_pdu.add_pduconfig"],
             ),

--- a/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_edit.html
+++ b/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_edit.html
@@ -1,2 +1,2 @@
-{% extends 'utilities/obj_edit.html' %}
+{% extends 'generic/object_edit.html' %}
 {% load form_helpers %}

--- a/axians_netbox_pdu/views.py
+++ b/axians_netbox_pdu/views.py
@@ -26,7 +26,7 @@ class PDUConfigCreateView(PermissionRequiredMixin, ObjectEditView):
 
     permission_required = "axians_netbox_pdu.add_pduconfig"
     model = PDUConfig
-    # queryset = PDUConfig.objects.all()
+    queryset = PDUConfig.objects.all()
     model_form = PDUConfigForm
     template_name = "axians_netbox_pdu/pduconfig_edit.html"
     default_return_url = "plugins:axians_netbox_pdu:pduconfig_list"


### PR DESCRIPTION
Filters have been renamed to Filtersets and been relocated under Netbox core. The NameSlugSearchFilterSet method is now OrganizationalModelFilterSet under netbox.filtersets