### PR TITLE
Add support for Netbox 3.x

### DIFF
--- a/axians_netbox_pdu/models.py
+++ b/axians_netbox_pdu/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-
+from django.urls import reverse
 from .choices import PDUUnitChoices
 
 
@@ -21,6 +21,9 @@ class PDUConfig(models.Model):
     def __str__(self):
         """String representation of an PDUConfig."""
         return f"{self.device_type}"
+
+    def get_absolute_url(self):
+        return reverse('dcim:devicetype', args=[self.device_type.id])
 
 
 class PDUStatus(models.Model):

--- a/axians_netbox_pdu/navigation.py
+++ b/axians_netbox_pdu/navigation.py
@@ -1,6 +1,16 @@
 from extras.plugins import PluginMenuButton, PluginMenuItem
 from utilities.choices import ButtonColorChoices
 
+from django.conf import settings
+from packaging import version
+
+NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
+
+if NETBOX_CURRENT_VERSION >= version.parse("3.0"):
+    import_icon_class = "mdi mdi-upload"
+else:
+    import_icon_class = "mdi mdi-database-import-outline"
+
 menu_items = (
     PluginMenuItem(
         link="plugins:axians_netbox_pdu:pduconfig_list",
@@ -17,8 +27,8 @@ menu_items = (
             PluginMenuButton(
                 link="plugins:axians_netbox_pdu:pduconfig_import",
                 title="Bulk Add",
-                icon_class="mdi mdi-database-import-outline",
-                color=ButtonColorChoices.BLUE,
+                icon_class=import_icon_class,
+                color=ButtonColorChoices.CYAN,
                 permissions=["axians_netbox_pdu.add_pduconfig"],
             ),
         ),

--- a/axians_netbox_pdu/template_content.py
+++ b/axians_netbox_pdu/template_content.py
@@ -4,6 +4,10 @@ from extras.plugins import PluginTemplateExtension
 
 from .utilities import get_rack_power_utilization
 
+from django.conf import settings
+from packaging import version
+
+NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
 
 class DevicePDUStatus(PluginTemplateExtension):
     model = "dcim.device"
@@ -11,9 +15,15 @@ class DevicePDUStatus(PluginTemplateExtension):
     def left_page(self):
         device = self.context["object"]
 
+        template_filename = ""
+        if NETBOX_CURRENT_VERSION >= version.parse("3.0"):
+            template_filename = "axians_netbox_pdu/device_power_usage_3_x.html"
+        else:
+            template_filename = "axians_netbox_pdu/device_power_usage.html"
+
         try:
             return self.render(
-                "axians_netbox_pdu/device_power_usage.html", extra_context={"pdustatus": device.pdustatus}
+                template_filename, extra_context={"pdustatus": device.pdustatus}
             )
         except ObjectDoesNotExist:
             return ""
@@ -27,6 +37,12 @@ class RackPDUStatus(PluginTemplateExtension):
 
         pdus = rack.devices.filter(rack=rack).exclude(pdustatus=None)
 
+        template_filename = ""
+        if NETBOX_CURRENT_VERSION >= version.parse("3.0"):
+            template_filename = "axians_netbox_pdu/rack_power_usage_3_x.html"
+        else:
+            template_filename = "axians_netbox_pdu/rack_power_usage.html"
+
         if pdus:
             (
                 total_available_power,
@@ -37,7 +53,7 @@ class RackPDUStatus(PluginTemplateExtension):
             ## fix issues with device not habing available power
 
             return self.render(
-                "axians_netbox_pdu/rack_power_usage.html",
+                template_filename,
                 extra_context={
                     "pdus": pdus,
                     "total_power_usage": total_power_usage,
@@ -56,9 +72,15 @@ class DeviceTypePDUConfig(PluginTemplateExtension):
     def right_page(self):
         device_type = self.context["object"]
 
+        template_filename = ""
+        if NETBOX_CURRENT_VERSION >= version.parse("3.0"):
+            template_filename = "axians_netbox_pdu/device_type_pduconfig_3_x.html"
+        else:
+            template_filename = "axians_netbox_pdu/device_type_pduconfig.html"
+
         try:
             return self.render(
-                "axians_netbox_pdu/device_type_pduconfig.html", extra_context={"pduconfig": device_type.pduconfig}
+                template_filename, extra_context={"pduconfig": device_type.pduconfig}
             )
         except ObjectDoesNotExist:
             return ""

--- a/axians_netbox_pdu/templates/axians_netbox_pdu/device_power_usage_3_x.html
+++ b/axians_netbox_pdu/templates/axians_netbox_pdu/device_power_usage_3_x.html
@@ -1,0 +1,29 @@
+{% load humanize %}
+
+<div class="card card-default">
+    <div class="card-header">
+        <strong>Power Information</strong>
+    </div>
+    <div class="card-body">
+        <table class="table table-hover attr-table">
+            <tbody>
+                <tr>
+                    <td>
+                        <span title="">Power Usage</span>
+                    </td>
+                    <td>
+                        <span>{{ pdustatus.get_power_usage }}</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <span>Last Updated</span>
+                    </td>
+                    <td>
+                        <span>{{ pdustatus.updated_at|naturaltime }}</span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/axians_netbox_pdu/templates/axians_netbox_pdu/device_type_pduconfig_3_x.html
+++ b/axians_netbox_pdu/templates/axians_netbox_pdu/device_type_pduconfig_3_x.html
@@ -1,0 +1,29 @@
+<div class="card card-default">
+    <div class="card-header">
+        <strong>Power Usage Configuration</strong>
+    </div>
+    <div class="card-body">
+        <table class="table table-hover attr-table">
+            <tbody>
+                <tr>
+                    <td>Object Identifier</td>
+                    <td>{{ pduconfig.power_usage_oid }}</a></td>
+                </tr>
+                <tr>
+                    <td>Power Usage Unit</td>
+                    <td>
+                        {{ pduconfig.power_usage_unit|title }}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    {% if perms.axians_netbox_pdu.change_pduconfig %}
+    <div class="card-footer text-end noprint">
+        <a href="{% url 'plugins:axians_netbox_pdu:pduconfig_edit' pk=pduconfig.pk %}"
+            class="btn btn-sm btn-warning"><span class="mdi mdi-pencil" aria-hidden="true"></span>
+            Edit</a>
+        <div class="clearfix"></div>
+    </div>
+    {% endif %}
+</div>

--- a/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_edit_3_x.html
+++ b/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_edit_3_x.html
@@ -1,0 +1,2 @@
+{% extends 'generic/object_edit.html' %}
+{% load form_helpers %}

--- a/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_list_3_x.html
+++ b/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_list_3_x.html
@@ -1,0 +1,93 @@
+{% extends 'base/layout.html' %}
+{% load buttons %}
+{% load helpers %}
+{% load render_table from django_tables2 %}
+{% load static %}
+
+{% block controls %}
+  <div class="controls">
+    <div class="control-group">
+      {% block extra_controls %}{% endblock %}
+      {% if permissions.add %}
+          {% add_button 'plugins:axians_netbox_pdu:pduconfig_add' %}
+      {% endif %}
+      {% if permissions.add %}
+          {% import_button 'plugins:axians_netbox_pdu:pduconfig_import' %}
+      {% endif %}
+    </div>
+  </div>
+{% endblock controls %}
+
+{% block tabs %}
+  <ul class="nav nav-tabs px-3">
+    {% block tab_items %}
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="object-list-tab" data-bs-toggle="tab" data-bs-target="#object-list" type="button" role="tab" aria-controls="edit-form" aria-selected="true">
+          {% block title %}PDU Device Type Configuration{% endblock %}
+          {% badge table.page.paginator.count %}
+        </button>
+      </li>
+      {% if filter_form %}
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="filters-form-tab" data-bs-toggle="tab" data-bs-target="#filters-form" type="button" role="tab" aria-controls="object-list" aria-selected="false">
+            Filters
+            {% if filter_form %}{% badge filter_form.changed_data|length bg_class="primary" %}{% endif %}
+          </button>
+        </li>
+      {% endif %}
+    {% endblock tab_items %}
+  </ul>
+{% endblock tabs %}
+
+{% block content-wrapper %}
+  <div class="tab-content">
+
+    <div class="tab-pane show active" id="object-list" role="tabpanel" aria-labelledby="object-list-tab">
+
+      {% if filter_form %}
+        {% applied_filters filter_form request.GET %}
+      {% endif %}
+
+      {% include 'inc/table_controls.html' with table_modal="RecordTable_config" %}
+
+      <form method="post" class="form form-horizontal">
+        {% csrf_token %}
+        <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
+
+        <div class="card">
+          <div class="card-body">
+            <div class="table-responsive">
+              {% render_table table 'inc/table.html' %}
+            </div>
+          </div>
+        </div>
+
+        {% if permissions.delete %}
+          {% with bulk_delete_url='plugins:axians_netbox_pdu:pduconfig_bulk_delete' %}
+            <div class="noprint bulk-buttons">
+              <div class="bulk-button-group">
+                {% block bulk_buttons %}{% endblock %}
+                {% if bulk_delete_url and permissions.delete %}
+                  <button type="submit" name="_delete" formaction="{% url bulk_delete_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-danger btn-sm">
+                    <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> Delete Selected
+                  </button>
+                {% endif %}
+              </div>
+            </div>
+          {% endwith %}
+        {% endif %}
+
+      </form>
+
+      {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
+    </div>
+
+    {% if filter_form %}
+      <div class="tab-pane show" id="filters-form" role="tabpanel" aria-labelledby="filters-form-tab">
+        {% include 'inc/filter_list.html' %}
+      </div>
+    {% endif %}
+  </div>
+
+  {% table_config_form table table_name="RecordTable" %}
+{% endblock content-wrapper %}

--- a/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_view_3_x.html
+++ b/axians_netbox_pdu/templates/axians_netbox_pdu/pduconfig_view_3_x.html
@@ -1,0 +1,8 @@
+{% extends 'base/layout.html' %}
+{% load buttons %}
+{% load plugins %}
+{% load helpers %}
+
+{% block content %}
+
+{% endblock %}

--- a/axians_netbox_pdu/templates/axians_netbox_pdu/rack_power_usage_3_x.html
+++ b/axians_netbox_pdu/templates/axians_netbox_pdu/rack_power_usage_3_x.html
@@ -1,0 +1,76 @@
+{% load humanize %}
+{% load helpers %}
+
+{% with config=settings.PLUGINS_CONFIG.axians_netbox_pdu %}
+{% if config.rack_view_pdu_devices %}
+<div class="card card-default">
+    <div class="card-header">
+        <strong>Power Usage Devices</strong>
+    </div>
+    <div class="card-body">
+        <table class="table table-hover attr-table">
+            <thead>
+                <tr>
+                    <th>
+                        Device
+                    </th>
+                    <th>
+                        Power Usage
+                    </th>
+                    <th>
+                        Last Updated
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for pdu in pdus %}
+                <tr>
+                    <td>
+                        <a href="{{pdu.get_absolute_url}}">{{pdu.name}}</a>
+                    </td>
+                    <td>
+                        <span title="">{{pdu.pdustatus.get_power_usage}}</span>
+                    </td>
+                    <td>
+                        <span>{{ pdu.pdustatus.updated_at|naturaltime }}</span>
+                    </td>
+                </tr>
+                {%endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endif %}
+
+{% if config.rack_view_usage_summary %}
+<div class="card card-default">
+    <div class="card-header">
+        <strong>Power Usage Summary</strong>
+    </div>
+    <div class="card-body">
+        <table class="table table-hover attr-table">
+            <tbody>
+                {% if total_power_usage_unit %}
+                <tr>
+                    <td>Total Power Usage</td>
+                    <td>{{ total_power_usage }} {{ total_power_usage_unit|title }}</td>
+                </tr>
+                {% endif %}
+                {% if total_available_power %}
+                <tr>
+                    <td>Total Power Available</td>
+                    <td>{{ total_available_power }} {{ total_power_usage_unit|title }}</td>
+                </tr>
+                {% endif %}
+                {% if total_power_usage_percentage %}
+                <tr>
+                    <td>Utilization</td>
+                    <td>{% utilization_graph total_power_usage_percentage %}</td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endif %}
+{% endwith %}

--- a/axians_netbox_pdu/views.py
+++ b/axians_netbox_pdu/views.py
@@ -9,6 +9,10 @@ from .forms import PDUConfigCSVForm, PDUConfigFilterForm, PDUConfigForm
 from .models import PDUConfig
 from .tables import PDUConfigBulkTable, PDUConfigTable
 
+from django.conf import settings
+from packaging import version
+
+NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
 
 class PDUConfigListView(PermissionRequiredMixin, ObjectListView):
     """View for listing all PDUConfig items"""
@@ -18,7 +22,10 @@ class PDUConfigListView(PermissionRequiredMixin, ObjectListView):
     filterset = PDUConfigFilter
     filterset_form = PDUConfigFilterForm
     table = PDUConfigTable
-    template_name = "axians_netbox_pdu/pduconfig_list.html"
+    if NETBOX_CURRENT_VERSION >= version.parse("3.0"):
+        template_name = "axians_netbox_pdu/pduconfig_list_3_x.html"
+    else:
+        template_name = "axians_netbox_pdu/pduconfig_list.html"
 
 
 class PDUConfigCreateView(PermissionRequiredMixin, ObjectEditView):
@@ -28,7 +35,10 @@ class PDUConfigCreateView(PermissionRequiredMixin, ObjectEditView):
     model = PDUConfig
     queryset = PDUConfig.objects.all()
     model_form = PDUConfigForm
-    template_name = "axians_netbox_pdu/pduconfig_edit.html"
+    if NETBOX_CURRENT_VERSION >= version.parse("3.0"):
+        template_name = "axians_netbox_pdu/pduconfig_edit_3_x.html"
+    else:
+        template_name = "axians_netbox_pdu/pduconfig_edit.html"
     default_return_url = "plugins:axians_netbox_pdu:pduconfig_list"
 
 
@@ -36,6 +46,7 @@ class PDUConfigImportView(PermissionRequiredMixin, BulkImportView):
     """View for bulk-importing a CSV file to create PDUConfigs"""
 
     permission_required = "axians_netbox_pdu.add_pduconfig"
+    queryset = PDUConfig.objects.all()
     model_form = PDUConfigCSVForm
     table = PDUConfigBulkTable
     default_return_url = "plugins:axians_netbox_pdu:pduconfig_list"

--- a/development/netbox_v2.11.7/configuration.py
+++ b/development/netbox_v2.11.7/configuration.py
@@ -1,0 +1,6 @@
+"""NetBox configuration file overrides specific to the latest MASTER version."""
+from .base_configuration import *  # pylint: disable=relative-beyond-top-level, wildcard-import
+
+# Overrides specific to this version go here
+REMOTE_AUTH_DEFAULT_PERMISSIONS = {}
+# REMOTE_AUTH_BACKEND = None

--- a/development/netbox_v3.0.11/configuration.py
+++ b/development/netbox_v3.0.11/configuration.py
@@ -1,0 +1,6 @@
+"""NetBox configuration file overrides specific to the latest MASTER version."""
+from .base_configuration import *  # pylint: disable=relative-beyond-top-level, wildcard-import
+
+# Overrides specific to this version go here
+REMOTE_AUTH_DEFAULT_PERMISSIONS = {}
+# REMOTE_AUTH_BACKEND = None


### PR DESCRIPTION
This commit add support for Netbox v3.x. Maintains support for Netbox v2.11.
Core functionality is untouched, however owing to the addition of a
`get_absolute_url` method for the PDUConfig class, behaviour when adding a
single PDUConfig is changed slightly. Only difference is upon successful
addition of the PDU Config you will be redirected to the device_type for
which the PDUConfig applies, rather than back to the PDUConfig list page.

This includes the following changes:
  - Add a get_absolute_url method of PDUConfig class
  - Add 3.x templates to use updated 3.x themes and icons.
  - Add code to use the appropriate templates based on running version
  - Fixes bulk import of PDUConfigs